### PR TITLE
Disabled autocapitalization behaviour for all inputs

### DIFF
--- a/src/components/EditExerciseForm.js
+++ b/src/components/EditExerciseForm.js
@@ -43,7 +43,12 @@ export default class EditExerciseForm extends Component<Props, State> {
     const { date, hasConfirmed, isSaving, exercise, time } = this.state;
 
     return (
-      <form className="new-form" disabled={isSaving} onSubmit={this._onSubmit}>
+      <form
+        className="new-form"
+        disabled={isSaving}
+        onSubmit={this._onSubmit}
+        autocapitalize="none"
+      >
         <section className="new-form-section">
           <div className="new-form-section-header">
             <DateIcon className="new-form-section-header-svg" />

--- a/src/components/EditFoodForm.js
+++ b/src/components/EditFoodForm.js
@@ -42,7 +42,12 @@ export default class NewFoodDrink extends Component<Props, State> {
     const { date, food, hasConfirmed, isSaving, time } = this.state;
 
     return (
-      <form className="new-form" disabled={isSaving} onSubmit={this._onSubmit}>
+      <form
+        className="new-form"
+        disabled={isSaving}
+        onSubmit={this._onSubmit}
+        autocapitalize="none"
+      >
         <section className="new-form-section">
           <div className="new-form-section-header">
             <DateIcon className="new-form-section-header-svg" />

--- a/src/components/EditSleepForm.js
+++ b/src/components/EditSleepForm.js
@@ -36,7 +36,12 @@ export default class EditSleepForm extends Component<Props, State> {
     const { date, hasConfirmed, isSaving, sleep } = this.state;
 
     return (
-      <form className="new-form" disabled={isSaving} onSubmit={this._onSubmit}>
+      <form
+        className="new-form"
+        disabled={isSaving}
+        onSubmit={this._onSubmit}
+        autocapitalize="none"
+      >
         <section className="new-form-section">
           <div className="new-form-section-header">
             <DateIcon className="new-form-section-header-svg" />

--- a/src/components/EditSymptomForm.js
+++ b/src/components/EditSymptomForm.js
@@ -43,7 +43,12 @@ export default class NewSymptom extends Component<Props, State> {
     const { date, hasConfirmed, isSaving, symptom, time } = this.state;
 
     return (
-      <form className="new-form" disabled={isSaving} onSubmit={this._onSubmit}>
+      <form
+        className="new-form"
+        disabled={isSaving}
+        onSubmit={this._onSubmit}
+        autocapitalize="none"
+      >
         <section className="new-form-section">
           <div className="new-form-section-header">
             <DateIcon className="new-form-section-header-svg" />


### PR DESCRIPTION
Modified all four Edit forms, even those that don't have a non-numeric input field - both for consistency and for future-proofing if such requirement gets added to take string inputs.

Addresses #17.

**Note**: it appears the `<form>` element was prettified by a precommit step (e.g. I'm guessing by the `prettier` package) - I'd considered doing this manually in the code but had decided to leave minimal impact on my first PR.  Automation took care of it anyway.