### PR TITLE
Update README to reflect current available login options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Try it out by signing in with your Google account at [personal-logger.now.sh](https://personal-logger.now.sh/).
+Try it out by signing in with your Github or Twitter account at [personal-logger.now.sh](https://personal-logger.now.sh/).
 
 ## Local Installation
 


### PR DESCRIPTION
Hey @bvaughn, just noticed that the project's README indicates you can sign in with your Google account, but I only see Github or Twitter as ways of logging into the app. I've updated the README to address this.

Feel free to close the PR if it's incorrect.